### PR TITLE
Change FolderEvents::PARENT_UPDATED by FolderEvents::PATH_UPDATED

### DIFF
--- a/MigrationBundle/Migrations/Version20170307181737.php
+++ b/MigrationBundle/Migrations/Version20170307181737.php
@@ -258,7 +258,7 @@ class Version20170307181737 extends AbstractMigration implements ContainerAwareI
         foreach ($rootFolders as $folder) {
             $event = $this->container->get('open_orchestra_media_admin.event.folder_event.factory')->createFolderEvent();
             $event->setFolder($folder);
-            $this->container->get('event_dispatcher')->dispatch(FolderEvents::PARENT_UPDATED, $event);
+            $this->container->get('event_dispatcher')->dispatch(FolderEvents::PATH_UPDATED, $event);
         }
 
         $this->container->get('object_manager')->flush();


### PR DESCRIPTION
[OO-BUGFIX] Update perimeters after a node or a folder has been moved
https://github.com/open-orchestra/open-orchestra-cms-bundle/pull/2253
https://github.com/open-orchestra/open-orchestra-media-admin-bundle/pull/384
https://github.com/open-orchestra/open-orchestra-migration-bundle/pull/13
https://github.com/open-orchestra/open-orchestra-model-interface/pull/307